### PR TITLE
NR-412452 

### DIFF
--- a/src/expandCollapseUtilities.js
+++ b/src/expandCollapseUtilities.js
@@ -111,20 +111,15 @@ function expandCollapseUtilities(cy) {
         cy.scratch("_cyExpandCollapse")?.tempOptions?.allowReArrangeLayout ??
         cy.scratch("_cyExpandCollapse")?.options?.allowReArrangeLayout;
 
-      async function handleReArrangeLayout() {
-        await new Promise((resolve) => {
-          elementUtilities.rearrange(layoutBy, layoutHandler);
-          if (cy.scratch("_cyExpandCollapse").selectableChanged) {
-            nodes.selectify();
-            cy.scratch("_cyExpandCollapse").selectableChanged = false;
-          }
-          resolve();
-        });
-      }
-
       if (allowReArrangeLayout) {
-        cy.ready(async function () {
-          await handleReArrangeLayout();
+        cy.ready(function () {
+          setTimeout(function () {
+            elementUtilities.rearrange(layoutBy, layoutHandler);
+            if (cy.scratch("_cyExpandCollapse").selectableChanged) {
+              nodes.selectify();
+              cy.scratch("_cyExpandCollapse").selectableChanged = false;
+            }
+          }, 0);
         });
       }
 

--- a/src/expandCollapseUtilities.js
+++ b/src/expandCollapseUtilities.js
@@ -111,15 +111,20 @@ function expandCollapseUtilities(cy) {
         cy.scratch("_cyExpandCollapse")?.tempOptions?.allowReArrangeLayout ??
         cy.scratch("_cyExpandCollapse")?.options?.allowReArrangeLayout;
 
+      async function handleReArrangeLayout() {
+        await new Promise((resolve) => {
+          elementUtilities.rearrange(layoutBy, layoutHandler);
+          if (cy.scratch("_cyExpandCollapse").selectableChanged) {
+            nodes.selectify();
+            cy.scratch("_cyExpandCollapse").selectableChanged = false;
+          }
+          resolve();
+        });
+      }
+
       if (allowReArrangeLayout) {
-        cy.ready(function () {
-          setTimeout(function () {
-            elementUtilities.rearrange(layoutBy, layoutHandler);
-            if (cy.scratch("_cyExpandCollapse").selectableChanged) {
-              nodes.selectify();
-              cy.scratch("_cyExpandCollapse").selectableChanged = false;
-            }
-          }, 0);
+        cy.ready(async function () {
+          await handleReArrangeLayout();
         });
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -587,7 +587,7 @@
             ).length
           : "0";
         if (String(defaultNodesCount) === "0") {
-          cy.remove(cluster);
+          cluster.hide()
           return;
         }
 
@@ -640,7 +640,7 @@
         opts
       ) {
         var cluster = cy.getElementById(clusterId);
-
+        if(cluster.hidden()) cluster.show()
         nodeIds.forEach((nodeId) => {
           var node = cy.getElementById(nodeId);
           node.move({ parent: clusterId });


### PR DESCRIPTION
- Cluster add back from the sidebar when it's shown from the hover does not create back the cluster
- Replacing setTimeout with Promise resolve.


Solution: 
- Rather than removing the cluster node when all the child nodes are expanded, we are hiding it, and showing the cluster node on collapse if it is hidden.